### PR TITLE
[FEAT] 채점 결과 (정답/오답/확인 필요) 반환 기능 추가

### DIFF
--- a/schema/grade_schema.py
+++ b/schema/grade_schema.py
@@ -2,10 +2,10 @@ from pydantic import BaseModel, field_validator
 
 
 class GetGradeRequest(BaseModel):
-    correct_answer: str
     answer: str
+    student_answer: str
 
-    @field_validator('correct_answer', 'answer')
+    @field_validator('answer', 'student_answer')
     def not_empty(cls, v):
         if not v or not v.strip():
             raise ValueError('빈 값은 허용되지 않습니다.')

--- a/service/grade.py
+++ b/service/grade.py
@@ -1,7 +1,15 @@
 import torch
+from enum import Enum
 
 from sentence_transformers import util
 from schema.grade_schema import GetGradeRequest
+
+
+# 채점 결과
+class TestResult(Enum):
+    CORRECT = "정답 :)"
+    NEEDS_CONFIRMATION = "해당 문항에 대한 정답 여부를 확인하기 어려워, 추가적인 확인이 필요합니다. 필요에 따라 답안을 다시 작성하실 수도 있습니다 :) "
+    WRONG = "오답 :("
 
 
 def predict_grade(request: GetGradeRequest):
@@ -14,4 +22,14 @@ def predict_grade(request: GetGradeRequest):
     embeddings = model.encode([request.answer, request.student_answer], convert_to_tensor=True, device='cpu')
 
     # 코사인 유사도 계산
-    return util.pytorch_cos_sim(embeddings[0], embeddings[1])[0][0].item()
+    cosine_similarity = util.pytorch_cos_sim(embeddings[0], embeddings[1])[0][0].item()
+
+    # todo: 채점 기준 수정
+    if cosine_similarity > 0.6:
+        result = TestResult.CORRECT.value
+    elif cosine_similarity < 0.4:
+        result = TestResult.WRONG.value
+    else:
+        result = TestResult.NEEDS_CONFIRMATION.value
+
+    return result

--- a/service/grade.py
+++ b/service/grade.py
@@ -11,7 +11,7 @@ def predict_grade(request: GetGradeRequest):
     model.eval()
 
     # 두 문장을 모델로 임베딩
-    embeddings = model.encode([request.correct_answer, request.answer], convert_to_tensor=True, device='cpu')
+    embeddings = model.encode([request.answer, request.student_answer], convert_to_tensor=True, device='cpu')
 
     # 코사인 유사도 계산
     return util.pytorch_cos_sim(embeddings[0], embeddings[1])[0][0].item()


### PR DESCRIPTION
Closes #9 

#### 1. 채점 기준은 아래와 같습니다. ( * 추후 채점 기준 수정이 필요합니다. )
- 정답: 0.6 ~ 1.0
- 확인필요: 0.41 ~ 0.59
- 오답: 0.0 ~ 0.4


#### 2. 변수명 통일을 위해 response 변수명을 수정했습니다. 
```
correct_answer -> answer
answer -> student_answer
```
해당 내용은 프론트측에게 전달하도록 하겠습니다 ㅎ-ㅎ


#### 3. 확인 필요 문구 
```
CORRECT = "정답 :)"
NEEDS_CONFIRMATION = "해당 문항에 대한 정답 여부를 확인하기 어려워, 추가적인 확인이 필요합니다. 필요에 따라 답안을 다시 작성하실 수도 있습니다 :) "
WRONG = "오답 :("
```
리턴되는 문구를 다음과 같이 작성해보았는데, 좋은 아이디어가 있다면 의견을 남겨주셔도 좋습니다 !!!!!!!!