### PR TITLE
[FIX] 채점 결과와 점수를 함께 반환하도록 수정

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,10 +11,7 @@ request 모범 답안, 학생 답안
 response 채점 결과
 """
 @app.post("/grade")
-async def get_grade(request: GetGradeRequest):
-    if not validate_request(request):
-        raise HTTPException(status_code=400, detail='빈 값은 허용되지 않습니다.')
-
+async def get_grade(request: PredictGradeRequest):
     try:
         return predict_grade(request)
     except Exception as e:

--- a/schema/grade_schema.py
+++ b/schema/grade_schema.py
@@ -1,6 +1,17 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
-class GetGradeRequest(BaseModel):
+class PredictGradeRequest(BaseModel):
     answer: str
     student_answer: str
+
+    @field_validator('answer', 'student_answer')
+    def not_empty(cls, v):
+        if not v or not v.strip():
+            raise ValueError('빈 값은 허용되지 않습니다.')
+        return v
+
+
+class PredictGradeResponse(BaseModel):
+    result: str
+    score: float


### PR DESCRIPTION
Closes #22 

다음과 같은 response dto 를 추가했습니다. 

```
class PredictGradeResponse(BaseModel):
    result: str # 채점 결과 -> 오답 :(
    score: float # 점수 -> 28
```